### PR TITLE
ci: Dependabot による依存自動更新を導入

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "deno"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "build"
+    groups:
+      textlint:
+        patterns:
+          - "textlint*"
+          - "@textlint/*"
+          - "@textlint-ja/*"
+          - "@proofdict/*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,8 @@ updates:
     groups:
       textlint:
         patterns:
-          - "textlint*"
+          - "textlint"
           - "@textlint/*"
-          - "@textlint-ja/*"
-          - "@proofdict/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## 概要

`.github/dependabot.yml` を追加し、Dependabot による依存の自動バージョン更新を導入します。

## 設定内容

- **deno ecosystem** (`deno.json` の `jsr:` / `npm:` imports 対象)
  - weekly、コミットメッセージ prefix は `build`
  - 同一 monorepo で lockstep リリースされる `textlint` 本体と `@textlint/*` は `groups` で 1 つの PR にまとめます (混在バージョンによる不整合の防止)
- **github-actions ecosystem** (`.github/workflows/` 対象)
  - weekly、コミットメッセージ prefix は `ci`

## 補足

- Dependabot の Deno サポートは [2026-06-09 の changelog](https://github.blog/changelog/2026-06-09-dependabot-version-updates-now-support-the-deno-ecosystem/) で追加されたもので、version updates のみ対応です (security updates は未対応)。
- preset 系 (`textlint-rule-preset-*`)・`@textlint-ja/*`・`@proofdict/*` は独立してバージョニングされるため group に含めず、個別 PR で更新します。
- `deno.json` 内の jsdelivr 経由 `https:` import 2 件は Dependabot の更新対象外です。
- `.github/workflows/gh-pages.yml` の actions (`actions/checkout@v2` 等) が古いため、マージ直後に github-actions 側の更新 PR がいくつか作成される見込みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)