### PR TITLE
ci: PR 作成時に lint を実行する workflow を追加

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: Lint
+on:
+  pull_request:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v7
+      - name: Setup Deno environment
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - name: Lint
+        run: deno task lint

--- a/deno.lock
+++ b/deno.lock
@@ -1,6 +1,7 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@aireone/deno-lint-curly@*": "0.2.0",
     "jsr:@gunshi/gunshi@0.37.1": "0.37.1",
     "jsr:@std/fs@1.0.24": "1.0.24",
     "jsr:@std/internal@^1.0.14": "1.0.14",
@@ -29,6 +30,9 @@
     "npm:yaml@2.9.0": "2.9.0"
   },
   "jsr": {
+    "@aireone/deno-lint-curly@0.2.0": {
+      "integrity": "c182ea5d2ed999c06ffa88a21aac2aed3cf0d14a1128d7fad3034337f7822b48"
+    },
     "@gunshi/gunshi@0.37.1": {
       "integrity": "99769d56874e0812f42514b939c7c1b37b74fc0e3e391ace41b4e323be2330b6",
       "dependencies": [

--- a/index.html
+++ b/index.html
@@ -25,25 +25,25 @@
     </div>
   </body>
   <style>
-    @media (prefers-color-scheme: dark) {
-      html {
-        filter: invert(0.9) hue-rotate(180deg) brightness(1);
-      }
+  @media (prefers-color-scheme: dark) {
+    html {
+      filter: invert(0.9) hue-rotate(180deg) brightness(1);
     }
+  }
 
-    body {
-      display: flex;
-      flex-direction: column;
-      height: 100vh;
-    }
+  body {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+  }
 
-    .api-container {
-      flex: 1 0 0;
-      overflow: hidden;
-    }
+  .api-container {
+    flex: 1 0 0;
+    overflow: hidden;
+  }
 
-    .SendButtonHolder > div > button {
-      display: none;
-    }
+  .SendButtonHolder > div > button {
+    display: none;
+  }
   </style>
 </html>


### PR DESCRIPTION
## 概要

PR 作成時に lint を実行する GitHub Actions workflow を追加します。

## 変更内容

- `.github/workflows/lint.yml` を新規作成
  - `pull_request` トリガーで `deno task lint` (lint:deno / lint:textlint / lint:redocly) を実行します
  - 既存の gh-pages.yml と同じ構成 (actions/checkout@v7 + denoland/setup-deno@v2、deno v2.x) に揃えています
- `index.html` を `deno fmt` で整形
  - 現状 main では `deno fmt --check` が index.html で失敗するため、このままでは workflow がすべての PR で赤になります。機械整形のみで内容の変更はありません
- `deno.lock` に lint plugin (`@aireone/deno-lint-curly`) のエントリを補完
  - main の lockfile に未収載のため、`deno task lint` を実行するたびにローカルで lockfile が書き換わる状態でした

## 補足

- `lint:redocly` の task 定義は `setTimeout(() => Deno.exit(0), 10000)` で 10 秒後に強制 exit 0 する構造のため、redocly が異常状態で exit しない場合でも CI が green になる余地があります (既存構造のため本 PR では触れていません)
- `permissions` の明示や依存キャッシュ (`setup-deno` の cache オプション) は、既存 workflow との整合を優先し見送っています

🤖 Generated with [Claude Code](https://claude.com/claude-code)