### PR TITLE
build: textlint-plugin-yaml-keys を 0.0.4 に更新

### DIFF
--- a/.textlintrc.js
+++ b/.textlintrc.js
@@ -2,7 +2,7 @@ const path = require("node:path");
 
 // textlint plugin yaml-keys のローカルラッパー (textlint/plugins/yaml-keys.ts) を
 // 絶対パスで参照する。ラッパーは別 repo ansanloms/textlint-plugin-yaml-keys の
-// ソースを import map (deno.json) 経由で jsDelivr から読み込む薄い再 export。
+// bundle 済み dist/index.js を import map (deno.json) 経由で jsDelivr から読み込む薄い再 export。
 // pluginId が npm package 名でないため "textlint-plugin-<id>" の解決には失敗するが、
 // その後段で textlint module-resolver が require.resolve(<id>) を試すため、
 // 絶対パスを渡せばローカル plugin として読み込まれる。

--- a/deno.json
+++ b/deno.json
@@ -12,7 +12,7 @@
   ],
   "imports": {
     "@ansanloms/redocly-plugin-inline-examples/": "https://cdn.jsdelivr.net/gh/ansanloms/redocly-plugin-inline-examples@0.0.1/",
-    "@ansanloms/textlint-plugin-yaml-keys/": "https://cdn.jsdelivr.net/gh/ansanloms/textlint-plugin-yaml-keys@0.0.2/",
+    "@ansanloms/textlint-plugin-yaml-keys": "https://cdn.jsdelivr.net/gh/ansanloms/textlint-plugin-yaml-keys@0.0.4/dist/index.js",
     "@gunshi/gunshi": "jsr:@gunshi/gunshi@0.37.1",
     "@proofdict/textlint-rule-proofdict": "npm:@proofdict/textlint-rule-proofdict@3.1.2",
     "@redocly/cli": "npm:@redocly/cli@2.46.2",

--- a/deno.lock
+++ b/deno.lock
@@ -13,6 +13,7 @@
     "npm:@gunshi/plugin-renderer@0.37.1": "0.37.1_@gunshi+plugin-i18n@0.37.1__@gunshi+plugin-global@0.37.1_@gunshi+plugin-global@0.37.1",
     "npm:@proofdict/textlint-rule-proofdict@3.1.2": "3.1.2",
     "npm:@redocly/cli@2.46.2": "2.46.2",
+    "npm:@redocly/openapi-core@2.32.2": "2.32.2",
     "npm:@stoplight/elements@9.0.24": "9.0.24_react@19.2.8_react-dom@19.2.8__react@19.2.8_@react-spectrum+provider@3.11.1__react@19.2.8__react-dom@19.2.8___react@19.2.8",
     "npm:@textlint-ja/textlint-rule-preset-ai-writing@1.7.0": "1.7.0",
     "npm:@textlint/kernel@15.8.0": "15.8.0",
@@ -531,9 +532,39 @@
         "react"
       ]
     },
+    "@redocly/ajv@8.18.1": {
+      "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
+      "dependencies": [
+        "fast-deep-equal",
+        "fast-uri",
+        "json-schema-traverse",
+        "require-from-string"
+      ]
+    },
     "@redocly/cli@2.46.2": {
       "integrity": "sha512-HkKT9X5Fbl6YZi8ChsDKIWBve93hVDdqGEGWf99x1B/lJgk59EHqWZQJV+oE/T27iVU9wBuOBkBUludWrH57Fg==",
       "bin": true
+    },
+    "@redocly/config@0.49.1": {
+      "integrity": "sha512-Eid8/bDcsf2bpTJ2qZhULflf6Y/TtoUFZt0+a5XZzjZj0uA8L8EQiY/nEdBd6lZQlZsnu8/cAUhTyBebnLi0gA==",
+      "dependencies": [
+        "json-schema-to-ts"
+      ]
+    },
+    "@redocly/openapi-core@2.32.2": {
+      "integrity": "sha512-2W74F9dEPv/cp87Ik6xGJzcA0yCpiQ23uIq5hWPfXhxrfCOw/Tn/mQn0pZXWOJR2oQvxXjGxqq1be827rY7Hsw==",
+      "dependencies": [
+        "@redocly/ajv",
+        "@redocly/config",
+        "ajv@npm:@redocly/ajv@8.18.1",
+        "ajv-formats",
+        "colorette",
+        "js-levenshtein",
+        "js-yaml@4.3.1",
+        "picomatch@4.0.5",
+        "pluralize@8.0.0",
+        "yaml-ast-parser"
+      ]
     },
     "@rehooks/component-size@1.0.3_react@19.2.8": {
       "integrity": "sha512-pnYld+8SSF2vXwdLOqBGUyOrv/SjzwLjIUcs/4c1JJgR0q4E9eBtBfuZMD6zUD51fvSehSsbnlQMzotSmPTXPg==",
@@ -1137,7 +1168,7 @@
         "debug",
         "js-yaml@4.3.1",
         "lodash@4.18.1",
-        "pluralize",
+        "pluralize@2.0.0",
         "string-width",
         "strip-ansi",
         "table",
@@ -1372,6 +1403,15 @@
     },
     "@xobotyi/scrollbar-width@1.9.5": {
       "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ=="
+    },
+    "ajv-formats@3.0.1_@redocly+ajv@8.18.1": {
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dependencies": [
+        "ajv@npm:@redocly/ajv@8.18.1"
+      ],
+      "optionalPeers": [
+        "ajv@npm:@redocly/ajv@8.18.1"
+      ]
     },
     "ajv@8.20.0": {
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
@@ -1631,6 +1671,9 @@
     },
     "color-name@1.1.4": {
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "colorette@1.4.0": {
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
     },
     "comma-separated-tokens@1.0.8": {
       "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw=="
@@ -2681,6 +2724,9 @@
     "js-cookie@3.0.8": {
       "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw=="
     },
+    "js-levenshtein@1.1.6": {
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="
+    },
     "js-sha3@0.8.0": {
       "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
     },
@@ -2718,6 +2764,14 @@
       "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
       "dependencies": [
         "lodash@4.18.1"
+      ]
+    },
+    "json-schema-to-ts@2.7.2": {
+      "integrity": "sha512-R1JfqKqbBR4qE8UyBR56Ms30LL62/nlhoz+1UkfI/VE7p54Awu919FZ6ZUPG8zIa3XB65usPJgr1ONVncUGSaQ==",
+      "dependencies": [
+        "@babel/runtime",
+        "@types/json-schema",
+        "ts-algebra"
       ]
     },
     "json-schema-traverse@1.0.0": {
@@ -3026,7 +3080,7 @@
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dependencies": [
         "braces",
-        "picomatch"
+        "picomatch@2.3.2"
       ]
     },
     "microseconds@0.2.0": {
@@ -3293,8 +3347,14 @@
     "picomatch@2.3.2": {
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="
     },
+    "picomatch@4.0.5": {
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="
+    },
     "pluralize@2.0.0": {
       "integrity": "sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw=="
+    },
+    "pluralize@8.0.0": {
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
     },
     "polished@4.3.1": {
       "integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
@@ -4354,6 +4414,9 @@
     "trough@1.0.5": {
       "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
     },
+    "ts-algebra@1.2.2": {
+      "integrity": "sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA=="
+    },
     "ts-easing@0.2.0": {
       "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
     },
@@ -4791,6 +4854,9 @@
     "xtend@4.0.2": {
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
+    "yaml-ast-parser@0.0.43": {
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="
+    },
     "yaml@1.10.3": {
       "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="
     },
@@ -4822,11 +4888,11 @@
   },
   "remote": {
     "https://cdn.jsdelivr.net/gh/ansanloms/redocly-plugin-inline-examples@0.0.1/deps/jsr/path.ts": "71b96c2a98a6bf26d0e8504acd485bea78bf81b4b47d6ecae33e7732e3bce452",
+    "https://cdn.jsdelivr.net/gh/ansanloms/redocly-plugin-inline-examples@0.0.1/deps/npm/openapi-core.ts": "4e71929aac9f0d97ad95ed901c4d66bbe6004e9301d1f6d2ddc89e89a8d60f76",
     "https://cdn.jsdelivr.net/gh/ansanloms/redocly-plugin-inline-examples@0.0.1/deps/npm/yaml.ts": "fe953b5cce89ec15625536e0515152abdf6bbce846c89885ff3b9a7b70cf5faf",
     "https://cdn.jsdelivr.net/gh/ansanloms/redocly-plugin-inline-examples@0.0.1/index.ts": "9d25751257a8d19d51a5bbaca883ddda1490eff3e3bc25959e6d59240fd5ff39",
     "https://cdn.jsdelivr.net/gh/ansanloms/redocly-plugin-inline-examples@0.0.1/preprocessors/inline-examples.ts": "a0b3a994c9810d63999452e5c7eee4971af683dd79795933f6e93343d6a5a4d3",
-    "https://cdn.jsdelivr.net/gh/ansanloms/textlint-plugin-yaml-keys@0.0.2/deps/npm/yaml.ts": "b023c720ef51ceaf0a11636277d72f28cd9d0b74089368ac63907f363f61b710",
-    "https://cdn.jsdelivr.net/gh/ansanloms/textlint-plugin-yaml-keys@0.0.2/index.ts": "3b16a79f58fd9e8eeae32c7e6964b2a54802c524b1b421253bb8cb50acf387ed"
+    "https://cdn.jsdelivr.net/gh/ansanloms/textlint-plugin-yaml-keys@0.0.4/dist/index.js": "315b3a3cb0fd3e55892bb77aaaf690606faf3aa36a1d76055fb4e147c95bf64a"
   },
   "workspace": {
     "dependencies": [

--- a/textlint/plugins/yaml-keys.ts
+++ b/textlint/plugins/yaml-keys.ts
@@ -3,10 +3,8 @@
 // textlint の plugin ローダは Node の require で動くため URL や import map の
 // specifier を直接は解決できないが、ローカルの ESM ファイルは絶対パスで
 // 読み込める。このファイル内の import は Deno の import map (deno.json の
-// "@ansanloms/textlint-plugin-yaml-keys/") 経由で jsDelivr のソースへ解決される。
-//
-// 配信物の index.js (deno bundle 出力) は createRequire(import.meta.url) を
-// 含み https を基底にできず URL import で落ちるため、ソースの index.ts を import する。
-import plugin from "@ansanloms/textlint-plugin-yaml-keys/index.ts";
+// "@ansanloms/textlint-plugin-yaml-keys") 経由で jsDelivr が配信する
+// bundle 済みの dist/index.js へ解決される。
+import plugin from "@ansanloms/textlint-plugin-yaml-keys";
 
 export default plugin;


### PR DESCRIPTION
## 概要

textlint plugin `ansanloms/textlint-plugin-yaml-keys` を 0.0.2 から 0.0.4 に更新する。

0.0.4 では配信形態が jsDelivr 上のソース (`index.ts`) から bundle 済みの `dist/index.js` (`deno bundle --platform=browser` 出力) に変わった。0.0.2 の bundle が持っていた `createRequire(import.meta.url)` は無くなり、https から直接 import できる。

## 変更内容

- `deno.json`: import map のエントリをディレクトリ prefix (`.../@0.0.2/`) から単一ファイルを指す bare specifier (`.../@0.0.4/dist/index.js`) に変更
- `textlint/plugins/yaml-keys.ts`: import 先を `@ansanloms/textlint-plugin-yaml-keys` に変更し、コメントを更新
- `.textlintrc.js`: コメントを更新
- `deno.lock`: 0.0.2 の 2 エントリを削除し、0.0.4 の `dist/index.js` のエントリを追加

## ラッパーを残す理由

textlint の plugin ローダ (`@textlint/config-loader`) は plugin ID を `require.resolve` で解決するため、URL や Deno の import map を直接は扱えない。ローカルの `textlint/plugins/yaml-keys.ts` を絶対パスで参照し、その中で import map 経由の import に切り替える構成は引き続き必要。

## 検証

- `deno task textlint . --ignore-path ./.gitignore` (CI と同じ引数): exit 0
- `description: 絞り込みユーザ ID！` を含む yaml に対して `ja-technical-writing/no-exclamation-question-mark` が発火することを確認 (plugin が値を抽出している)
- `deno lint` / `deno fmt --check`: exit 0
- `deno.lock` のハッシュが jsDelivr 配信物の sha256 と一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)
