### PR TITLE
fix: index.html の style 要素を head 内へ移動

### DIFF
--- a/.textlintrc.js
+++ b/.textlintrc.js
@@ -11,6 +11,9 @@
 //     filter・plugin を後から足すときも、同じ形のラッパーディレクトリを textlint/ に置く。
 //   - ラッパーの解決に失敗しても textlint は "No rules found" としか出さない。原因は
 //     `DEBUG='textlint:*' deno task textlint --debug <file>` で確認できる。
+//   - preset-ansanloms と yaml-keys の実体は deno.json の import map で jsDelivr の
+//     タグ付き URL に固定している。Dependabot の deno エコシステムは npm: / jsr: 指定しか
+//     更新しないため、これら 2 件のバージョン更新は deno.json の URL を手で書き換える。
 //
 // 個別 rule の options は preset 側 (ansanloms/textlint-rule-preset-ansanloms の index.ts) が
 // 持ち、ここでは上書きしない。

--- a/index.html
+++ b/index.html
@@ -14,6 +14,28 @@
       rel="stylesheet"
       href="https://unpkg.com/@stoplight/elements/styles.min.css"
     />
+    <style>
+    @media (prefers-color-scheme: dark) {
+      html {
+        filter: invert(0.9) hue-rotate(180deg) brightness(1);
+      }
+    }
+
+    body {
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+    }
+
+    .api-container {
+      flex: 1 0 0;
+      overflow: hidden;
+    }
+
+    .SendButtonHolder > div > button {
+      display: none;
+    }
+    </style>
   </head>
   <body>
     <div class="api-container">
@@ -24,26 +46,4 @@
       />
     </div>
   </body>
-  <style>
-  @media (prefers-color-scheme: dark) {
-    html {
-      filter: invert(0.9) hue-rotate(180deg) brightness(1);
-    }
-  }
-
-  body {
-    display: flex;
-    flex-direction: column;
-    height: 100vh;
-  }
-
-  .api-container {
-    flex: 1 0 0;
-    overflow: hidden;
-  }
-
-  .SendButtonHolder > div > button {
-    display: none;
-  }
-  </style>
 </html>


### PR DESCRIPTION
## 概要

- `index.html` の `<style>` 要素を `</body>` の後ろから `<head>` 内 (stylesheet link の直後) へ移動する。HTML パーサによる body 末尾への再配置が無くなり、dark mode の `filter` が初回描画から適用される。CSS の中身は変更しない。
- `.textlintrc.js` の冒頭コメントに、jsDelivr URL 固定の `preset-ansanloms` と `yaml-keys` は Dependabot の更新対象外で、`deno.json` の URL を手で書き換える必要がある旨を追記する。

Closes #32
Closes #26

## 検証

- `deno task lint` 成功
- `deno task build` 成功。生成された `dist/index.html` で `<style>` が `</head>` より前にあることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvzPpNbzGXsJ8Dnx33goed
