### PR TITLE
ci: workflows の permissions と concurrency と依存キャッシュを整備

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,22 @@ updates:
     commit-message:
       prefix: "build"
     groups:
-      textlint:
+      deno:
         patterns:
-          - "textlint"
-          - "@textlint/*"
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,6 +2,11 @@ name: Publish on GitHub Pages
 on:
   push:
     branches: [main]
+permissions:
+  contents: write
+concurrency:
+  group: pages
+  cancel-in-progress: false
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -12,6 +17,7 @@ jobs:
         uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
+          cache: true
       - name: Build site
         run: deno task build
       - name: Deploy

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,13 @@
 name: Lint
 on:
+  push:
+    branches: [main]
   pull_request:
+permissions:
+  contents: read
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -11,5 +18,8 @@ jobs:
         uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
+          cache: true
       - name: Lint
         run: deno task lint
+      - name: Build
+        run: deno task build


### PR DESCRIPTION
## 概要

### `.github/workflows/lint.yml`

- `push: branches: [main]` トリガーを追加し、main への直接 push も lint する。
- `permissions: contents: read` を明示する。
- `concurrency` を追加する。PR への連続 push では古い run を cancel し、main への push は cancel せず走り切る (`cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`)。
- `setup-deno` に `cache: true` を付け、`deno.lock` のハッシュをキーに依存をキャッシュする。
- `deno task build` ステップを追加する。`deno check` では拾えない `bin/build.ts` の実行時エラー (アセット名の変更等) を PR で検出する。

### `.github/workflows/gh-pages.yml`

- `permissions: contents: write` を明示する (action の README の使用例と同じ)。
- `concurrency: {group: pages, cancel-in-progress: false}` を追加する。近接した push はキュー順に実行され、古い dist が後から上書きすることが無くなる。デプロイ中の run は cancel しない。
- `setup-deno` に `cache: true` を付ける。

### `.github/dependabot.yml`

- `deno` と `github-actions` の両エコシステムで全依存を 1 グループにまとめる (`patterns: ["*"]`)。
- `update-types: ["minor", "patch"]` で minor と patch のみ束ね、major は個別 PR にする。

Closes #25
Closes #29
Closes #30
Closes #31
Closes #33

## 補足

- #31 のうち redocly タスクの固定 10 秒待ちは #36 で解消済み。proofdict の外部 fetch は preset 側 (`textlint-rule-preset-ansanloms`) の設定で、このリポジトリでは扱わない。
- `actionlint` は環境に無く実行していない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvzPpNbzGXsJ8Dnx33goed
