### PR TITLE
ci: gh-pages を build と deploy の 2 job に分割し workflows に timeout を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,3 @@ updates:
       github-actions:
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,13 +3,14 @@ on:
   push:
     branches: [main]
 permissions:
-  contents: write
+  contents: read
 concurrency:
   group: pages
   cancel-in-progress: false
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Clone repository
         uses: actions/checkout@v7
@@ -20,6 +21,24 @@ jobs:
           cache: true
       - name: Build site
         run: deno task build
+      - name: Upload site
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+          overwrite: true
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Download site
+        uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist
       - name: Deploy
         uses: crazy-max/ghaction-github-pages@v5.0.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Clone repository
         uses: actions/checkout@v7


### PR DESCRIPTION
## 概要

### `.github/workflows/gh-pages.yml`

- workflow レベルの `permissions` を `contents: read` にし、`build` と `deploy` の 2 job に分割する。`deploy` job だけ `contents: write` を持つ。
- `dist/` は `actions/upload-artifact@v7` と `actions/download-artifact@v8` で受け渡す。`deploy` job に checkout は無い (`crazy-max/ghaction-github-pages` の README の使用例と同じ)。
- 両 job に `timeout-minutes: 10` を付ける。

### `.github/workflows/lint.yml`

- `lint` job に `timeout-minutes: 10` を付ける。

### `.github/dependabot.yml`

- `github-actions` グループの `update-types` を外し、major も束ねる。`@vN` 固定の action (checkout, setup-deno) の更新は必ず major になるため、minor と patch に限ると `ghaction-github-pages` の patch しかグループに入らなかった。`deno` グループは変えない。

Closes #39
Closes #40
Closes #42

## 検証

- `deno task lint` 成功 (fmt --check が YAML を検査)。
- マージ後の main push で build と deploy の 2 job が通ることを確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvzPpNbzGXsJ8Dnx33goed
