### PR TITLE
build: fix タスクで textlint --fix を fmt より前に実行

### DIFF
--- a/.textlintrc.js
+++ b/.textlintrc.js
@@ -12,8 +12,12 @@
 //   - ラッパーの解決に失敗しても textlint は "No rules found" としか出さない。原因は
 //     `DEBUG='textlint:*' deno task textlint --debug <file>` で確認できる。
 //   - preset-ansanloms と yaml-keys の実体は deno.json の import map で jsDelivr の
-//     タグ付き URL に固定している。Dependabot の deno エコシステムは npm: / jsr: 指定しか
-//     更新しないため、これら 2 件のバージョン更新は deno.json の URL を手で書き換える。
+//     タグ付き URL に固定している。同様に URL 固定の依存として、ディレクトリ指定の
+//     redocly-plugin-inline-examples がある (計 3 件)。Dependabot の deno エコシステムは
+//     npm: / jsr: 指定しか更新しないため、これらのバージョン更新は deno.json の URL を
+//     手で書き換え、`deno install` と `deno task lint` を実行して deno.lock を更新する
+//     (ディレクトリ指定の redocly-plugin-inline-examples は `deno install` では解決されず、
+//     redocly タスクの実行時に deno.lock へ反映される)。
 //
 // 個別 rule の options は preset 側 (ansanloms/textlint-rule-preset-ansanloms の index.ts) が
 // 持ち、ここでは上書きしない。

--- a/deno.json
+++ b/deno.json
@@ -45,7 +45,7 @@
     "lint:deno": "deno lint && deno fmt --check",
     "lint:textlint": "deno task textlint . --ignore-path ./.gitignore",
     "lint:redocly": "deno task redocly lint --config ./redocly.yaml",
-    "fix": "deno task sort; deno task fix:deno; deno task fix:textlint; deno task lint",
+    "fix": "deno task sort; deno task fix:textlint; deno task fix:deno; deno task lint",
     "fix:deno": "deno lint --fix; deno fmt",
     "fix:textlint": "deno task textlint . --fix --ignore-path ./.gitignore",
     "build": "deno task build:clean && deno task build:bundle && deno task build:build",


### PR DESCRIPTION
## 概要

- `deno.json` の `fix` タスクを `sort; fix:textlint; fix:deno; lint` の順にし、`textlint --fix` の書き込みが `deno fmt` より前になるようにする。
- `.textlintrc.js` の冒頭コメントを修正する。jsDelivr のタグ付き URL で固定している依存はディレクトリ指定の `redocly-plugin-inline-examples` を含めて 3 件あること、URL を書き換えた後は `deno install` と `deno task lint` で `deno.lock` を更新すること (ディレクトリ指定の 1 件は `deno install` では解決されず redocly タスクの実行時に反映される) を書く。

Closes #38
Closes #41

## 検証

- `deno task lint` 成功、`deno task fix` 成功 (整形差分なし)。
- lock 更新手順の実証: `textlint-plugin-yaml-keys` のタグを一時的に `0.0.3` にして `deno install` を実行すると `deno.lock` に新しい URL のエントリが追加される (古いタグのエントリは残る)。`redocly-plugin-inline-examples` のエントリを `deno.lock` から消すと `deno install` では戻らず、`deno task lint:redocly` で戻る。いずれも確認後に元へ戻した。
- #38 の「fmt --check が落ちる」具体例は、preset-ansanloms のルール (句読点統一、全角半角間スペース) を markdown 段落・表・YAML scalar で試した範囲では再現しなかった。順序の入れ替えは構成上の是正として行う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvzPpNbzGXsJ8Dnx33goed
