### PR TITLE
ci: gh-pages の artifact 受け渡しと build の権限を固める

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -27,6 +27,7 @@ jobs:
           name: dist
           path: dist/
           overwrite: true
+          include-hidden-files: true
   deploy:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,6 +11,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - name: Clone repository
         uses: actions/checkout@v7
@@ -28,6 +30,8 @@ jobs:
           path: dist/
           overwrite: true
           include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 1
   deploy:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 概要

`.github/workflows/gh-pages.yml` の build job と artifact 受け渡しを固める。

### upload-artifact (`Upload site` ステップ)

- `include-hidden-files: true`: 分割前は `dist/` をそのまま push していたので dotfile も配信されていた。将来 `.nojekyll` や `.well-known/` を出力するようになったとき、黙って欠けないようにする。現状の `dist/` に dotfile は無い。
- `if-no-files-found: error`: `dist/` が空のとき build job で失敗させる。既定の `warn` だと deploy の download まで露見がずれる。
- `retention-days: 1`: 同じ run の build から deploy へ渡すためだけの artifact (約 2.4 MB) を既定期間残さない。

### build job

- `permissions: contents: read` を明示する。workflow レベルを将来広げても build job の権限が連動しない。

Closes #45
Closes #46
Closes #47
Closes #48

## 検証

- `deno task lint` 成功。
- マージ後の main push で build と deploy の両 job が success になることを確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvzPpNbzGXsJ8Dnx33goed
